### PR TITLE
Add a check for the response code to all Jira API calls.

### DIFF
--- a/src/jira-reporter.coffee
+++ b/src/jira-reporter.coffee
@@ -173,7 +173,7 @@ fetchRecentlyClosedStories = (robot) ->
 
       new Promise (resolve, reject) ->
         getFromJira robot, requestUrl, (err, resp, body) ->
-          unless resp.statusCode == 200
+          unless resp.statusCode <= 200 && resp.statusCode <= 299
             reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
           try
             bodyObj = JSON.parse(body)

--- a/src/jira-reporter.coffee
+++ b/src/jira-reporter.coffee
@@ -92,7 +92,7 @@ fetchSprints = (robot) ->
 
   return new Promise (resolve, reject) ->
     getFromJira robot, requestUrl, (err, resp, body) ->
-      unless resp.statusCode == 200
+      unless resp.statusCode <= 200 && resp.statusCode <= 299
         reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
       try
         bodyObj = JSON.parse(body)
@@ -106,7 +106,7 @@ fetchUser = (robot, user) ->
 
   return new Promise (resolve, reject) ->
     getFromJira robot, requestUrl, (err, resp, body) ->
-      unless resp.statusCode == 200
+      unless resp.statusCode <= 200 && resp.statusCode <= 299
         reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
       try
         user = JSON.parse(body)
@@ -122,7 +122,7 @@ fetchUsers = (robot) ->
 
   return new Promise (resolve, reject) ->
     getFromJira robot, requestUrl, (err, resp, body) ->
-      unless resp.statusCode == 200
+      unless resp.statusCode <= 200 && resp.statusCode <= 299
         reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
       try
         users = JSON.parse(body)
@@ -155,7 +155,7 @@ fetchInProgressSubtasks = (robot) ->
 
       new Promise (resolve, reject) ->
         getFromJira robot, requestUrl, (err, resp, body) ->
-          unless resp.statusCode == 200
+          unless resp.statusCode <= 200 && resp.statusCode <= 299
             reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
           try
             bodyObj = JSON.parse(body)

--- a/src/jira-reporter.coffee
+++ b/src/jira-reporter.coffee
@@ -92,6 +92,8 @@ fetchSprints = (robot) ->
 
   return new Promise (resolve, reject) ->
     getFromJira robot, requestUrl, (err, resp, body) ->
+      unless resp.statusCode == 200
+        reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
       try
         bodyObj = JSON.parse(body)
         sprints = bodyObj.sprints || []
@@ -104,6 +106,8 @@ fetchUser = (robot, user) ->
 
   return new Promise (resolve, reject) ->
     getFromJira robot, requestUrl, (err, resp, body) ->
+      unless resp.statusCode == 200
+        reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
       try
         user = JSON.parse(body)
         resolve user
@@ -118,6 +122,8 @@ fetchUsers = (robot) ->
 
   return new Promise (resolve, reject) ->
     getFromJira robot, requestUrl, (err, resp, body) ->
+      unless resp.statusCode == 200
+        reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
       try
         users = JSON.parse(body)
 
@@ -149,6 +155,8 @@ fetchInProgressSubtasks = (robot) ->
 
       new Promise (resolve, reject) ->
         getFromJira robot, requestUrl, (err, resp, body) ->
+          unless resp.statusCode == 200
+            reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
           try
             bodyObj = JSON.parse(body)
             issues = bodyObj.issues || []
@@ -165,6 +173,8 @@ fetchRecentlyClosedStories = (robot) ->
 
       new Promise (resolve, reject) ->
         getFromJira robot, requestUrl, (err, resp, body) ->
+          unless resp.statusCode == 200
+            reject new Error("Fetch failure. #{resp.statusCode}:#{resp.statusMessage}")
           try
             bodyObj = JSON.parse(body)
             issues = bodyObj.issues || []


### PR DESCRIPTION
This just makes it more obvious what the problem is when we get a non-200 response from the api. Currently, when that happens, we fail on JSON parsing and get a cryptic "Unexpected token <" error. 

/cc: @theazureshadow 